### PR TITLE
Fix static path for Docker

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -26,14 +26,8 @@ app.add_middleware(
 )
 
 
-# Path to the directory where src/api.py is located
-current_dir = os.path.dirname(__file__)
-
-# Path to the static directory
-static_dir = os.path.join("", "static/dist")
-
 # Mount the Frontend
-app.mount("/static", StaticFiles(directory=static_dir), name="static")
+app.mount("/static", StaticFiles(directory="/app/static"), name="static")
 
 
 @app.get("/")


### PR DESCRIPTION
This pull request fixes the static path for Docker by updating the directory path in the code. Previously, the path was set to `static/dist`, but it has been updated to `/app/static` to ensure the correct static files are served.